### PR TITLE
Remove redis dlq worker pool

### DIFF
--- a/v1/brokers/redis/goredis-dlq.go
+++ b/v1/brokers/redis/goredis-dlq.go
@@ -319,13 +319,13 @@ func (b *BrokerGR_DLQ) consumeOne(delivery []byte, taskProcessor iface.TaskProce
 	// If the task is not registered, we requeue it,
 	// there might be different workers for processing specific tasks
 	if !b.IsTaskRegistered(signature.Name) {
-		log.INFO.Printf("Task not registered with this worker. Requeing message: %s", delivery)
+		log.INFO.Printf("Task not registered with this worker. Requeing message: %+v", signature)
 
 		b.rclient.RPush(getQueueGR(b.GetConfig(), taskProcessor), delivery)
 		return nil
 	}
 
-	log.DEBUG.Printf("Received new message: %s", delivery)
+	log.DEBUG.Printf("Received new message: %+v", signature)
 
 	if err := taskProcessor.Process(signature); err != nil {
 		return err

--- a/v1/factories.go
+++ b/v1/factories.go
@@ -62,7 +62,7 @@ func BrokerFactory(cnf *config.Config) (brokeriface.Broker, error) {
 		parts := strings.Split(cnf.Broker, "redis+dlq://")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf(
-				"Redis DLQ broker connection string should be in format redis://host:port, instead got %s",
+				"Redis DLQ broker connection string should be in format redis+dlq://host:port, instead got %s",
 				cnf.Broker,
 			)
 		}


### PR DESCRIPTION
Previously, one channel used to hold tasks in-memory, and the tasks
waited to be processed until the machinery worker had was able to
process them. In the go-redis-dlq broker, visibilityTimeout starts
immediately after the task has been fetched from redis, which meant the
visibilityTimeout of the task was draining even if it was waiting to be
processed by machinery.

Removed the separate pool for worker instances, bringing it inline to
the SQS broker, where there is only one pool of task workers, and
messages are only fetched from redis if a worker is present to process
them immediately.