### PR TITLE
Fix: use redis db if provided in config URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/RichardKnop/redsync v1.2.0
 	github.com/aws/aws-sdk-go v1.25.8
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/btcsuite/btcutil v1.0.2 // indirect
+	github.com/btcsuite/btcutil v1.0.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/v1/brokers/redis/goredis-dlq.go
+++ b/v1/brokers/redis/goredis-dlq.go
@@ -43,20 +43,8 @@ type BrokerGR_DLQ struct {
 }
 
 // NewGR_DLQ creates new Broker instance
-func NewGR_DLQ(cnf *config.Config, addrs []string, db int) iface.Broker {
+func NewGR_DLQ(cnf *config.Config, addrs []string, password string, db int) iface.Broker {
 	b := &BrokerGR_DLQ{Broker: common.NewBroker(cnf)}
-	for i, addr := range addrs {
-		//go-redis URI can't handle db at the end of URI
-		addrs[i] = strings.Split(addr, "/")[0]
-	}
-
-	var password string
-	parts := strings.Split(addrs[0], "@")
-	if len(parts) == 2 {
-		// with passwrod
-		password = parts[0]
-		addrs[0] = parts[1]
-	}
 
 	ropt := &redis.UniversalOptions{
 		Addrs:    addrs,
@@ -64,6 +52,7 @@ func NewGR_DLQ(cnf *config.Config, addrs []string, db int) iface.Broker {
 		Password: password,
 	}
 	if cnf.Redis != nil {
+		// if we're specifying MasterName here, then we'll always connect to db 0, since provided db is ignored in cluster mode
 		ropt.MasterName = cnf.Redis.MasterName
 	}
 


### PR DESCRIPTION
Added fixes for connecting to different redis db's. It was hardcoded to 0 before, because we can receive a list of addresses in the go-redis broker(in failover and cluster mode). Even if multiple addresses are provided, the DB must be the same.

Added checks to make sure that all DB's (if) provided in the URL are the same.
In the same vein, added checks to ensure that all the passwords provided in URL are the same.
Please check `TestParseRedisDlqURL` for list of possible URL use-cases