### PR TITLE
feat: add more configs for use with redis clients

### DIFF
--- a/v1/brokers/redis/goredis-dlq.go
+++ b/v1/brokers/redis/goredis-dlq.go
@@ -50,6 +50,15 @@ func NewGR_DLQ(cnf *config.Config, addrs []string, password string, db int) ifac
 		Addrs:    addrs,
 		DB:       db,
 		Password: password,
+		ReadTimeout: time.Duration(cnf.Redis.ReadTimeout) * time.Second,
+		WriteTimeout: time.Duration(cnf.Redis.WriteTimeout) * time.Second,
+		DialTimeout: time.Duration(cnf.Redis.ConnectTimeout) * time.Second,
+		IdleTimeout: time.Duration(cnf.Redis.IdleTimeout) * time.Second,
+		MinIdleConns: cnf.Redis.MinIdleConns,
+		MinRetryBackoff: time.Duration(cnf.Redis.MinRetryBackoff) * time.Millisecond,
+		MaxRetryBackoff: time.Duration(cnf.Redis.MaxRetryBackoff) * time.Millisecond,
+		MaxRetries: cnf.Redis.MaxRetries,
+		PoolSize: cnf.Redis.PoolSize,
 	}
 	if cnf.Redis != nil {
 		// if we're specifying MasterName here, then we'll always connect to db 0, since provided db is ignored in cluster mode

--- a/v1/config/config.go
+++ b/v1/config/config.go
@@ -137,6 +137,27 @@ type RedisConfig struct {
 	// Default: 15
 	ConnectTimeout int `yaml:"connect_timeout" envconfig:"REDIS_CONNECT_TIMEOUT"`
 
+	// Minimum number of idle connections which is useful when establishing
+	// new connection is slow.
+	// Used in redis-dlq broker
+	MinIdleConns int `yaml:"min_idle_conns" envconfig:"REDIS_MIN_IDLE_CONNS"`
+
+	// Minimum backoff between each retry.
+	// Used in redis-dlq broker
+	// Default: 8 * time.Millisecond
+	MinRetryBackoff int `yaml:"min_retry_backoff" envconfig:"REDIS_MIN_RETRY_BACKOFF"`
+
+	// Maximum backoff between each retry.
+	// Used in redis-dlq broker
+	// Default: 512 * time.Millisecond
+	MaxRetryBackoff int `yaml:"max_retry_backoff" envconfig:"REDIS_MAX_RETRY_BACKOFF"`
+
+	// Default: 0 (no retries)
+	MaxRetries int `yaml:"max_retries" envconfig:"REDIS_MAX_RETRIES"`
+
+	// Default: 0 (pool size defaults to 10 * NumCpus)
+	PoolSize int `yaml:"pool_size" envconfig:"REDIS_POOL_SIZE"`
+
 	// VisibilityTimeout used in redis-dlq broker
 	// default to nil to use the overall visibility timeout for redis messages
 	VisibilityTimeout *int64 `yaml:"visibility_timeout" envconfig:"REDIS_VISIBILITY_TIMEOUT"`


### PR DESCRIPTION
additional configs are not usable with the default redis broker, so they've only be added for our redis-dlq broker