### PR TITLE
print old and new UUID when processing redis-dlq task

### DIFF
--- a/v1/brokers/redis/goredis-dlq.go
+++ b/v1/brokers/redis/goredis-dlq.go
@@ -299,6 +299,7 @@ func (b *BrokerGR_DLQ) consumeOne(delivery []byte, taskProcessor iface.TaskProce
 		return errs.NewErrCouldNotUnmarshaTaskSignature(delivery, err)
 	}
 	// propagating hash UUID for possible application usage, for example, refreshing visibility
+	oldUuid := signature.UUID
 	gHashByte := sha256.Sum256(delivery)
 	gHash := fmt.Sprintf(taskPrefix, base58.Encode(gHashByte[:sha256.Size]))
 	signature.UUID = gHash
@@ -313,6 +314,7 @@ func (b *BrokerGR_DLQ) consumeOne(delivery []byte, taskProcessor iface.TaskProce
 	}
 
 	log.DEBUG.Printf("Received new message: %+v", signature)
+	log.INFO.Printf("Processing task. Old UUID: %s New UUID: %s", oldUuid, signature.UUID)
 
 	if err := taskProcessor.Process(signature); err != nil {
 		// stop task deletion in case we want to send messages to dlq in redis


### PR DESCRIPTION
added INFO log that prints the old task UUID as well as the new hash UUID inside the redis-dlq broker

`2021-06-30T14:41:12.400+0500    INFO:   redis/goredis-dlq.go:317        Processing task. Old UUID: task_82531fa2-1d37-470f-82ed-2153f99a5bce. New UUID: task_2zunx9GDSZMgBF89TGZRU8HxuKThikcLFd8YTEHqqrEG`