### PR TITLE
FIX: Log sending message error at INFO level #DONE

### DIFF
--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -21,7 +20,6 @@ import (
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 const (
@@ -195,12 +193,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		if strings.Contains(err.Error(), sqs.ErrCodeQueueDoesNotExist) &&
-			strings.HasPrefix(signature.RoutingKey, fmt.Sprintf("t-%s-", os.Getenv("environment"))) {
-			log.INFO.Printf("Error source queue %s doesn't exist: %v", signature.RoutingKey, err)
-		} else {
-			log.ERROR.Printf("Error when sending a message: %v", err)
-		}
+		log.INFO.Printf("Error when sending a message: %v", err)
 		return err
 
 	}

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -20,7 +20,6 @@ import (
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
-	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 const (
@@ -194,7 +193,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		if strings.Contains(err.Error(), sqs.ErrCodeQueueDoesNotExist) {
+		if strings.Contains(err.Error(), (&types.QueueDoesNotExist{}).ErrorCode()) {
 			log.INFO.Printf("Error Queue doesn't exist: %v", err)
 		} else {
 			log.ERROR.Printf("Error when sending a message: %v", err)

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -20,6 +20,7 @@ import (
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 const (
@@ -193,7 +194,11 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		log.ERROR.Printf("Error when sending a message: %v", err)
+		if strings.Contains(err.Error(), sqs.ErrCodeQueueDoesNotExist) {
+			log.INFO.Printf("Error Queue doesn't exist: %v", err)
+		} else {
+			log.ERROR.Printf("Error when sending a message: %v", err)
+		}
 		return err
 
 	}

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -193,8 +194,9 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		if strings.Contains(err.Error(), (&types.QueueDoesNotExist{}).ErrorCode()) {
-			log.INFO.Printf("Error Queue doesn't exist: %v", err)
+		if strings.Contains(err.Error(), (&types.QueueDoesNotExist{}).ErrorCode()) &&
+			strings.HasPrefix(signature.RoutingKey, fmt.Sprintf("t-%s-", os.Getenv("environment"))) {
+			log.INFO.Printf("Error source queue doesn't exist: %v", err)
 		} else {
 			log.ERROR.Printf("Error when sending a message: %v", err)
 		}

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/sqs"
 	"os"
 	"strings"
 	"sync"
@@ -194,9 +195,9 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		if strings.Contains(err.Error(), (&types.QueueDoesNotExist{}).ErrorCode()) &&
+		if strings.Contains(err.Error(), sqs.ErrCodeQueueDoesNotExist) &&
 			strings.HasPrefix(signature.RoutingKey, fmt.Sprintf("t-%s-", os.Getenv("environment"))) {
-			log.INFO.Printf("Error source queue doesn't exist: %v", err)
+			log.INFO.Printf("Error source queue %s doesn't exist: %v", signature.RoutingKey, err)
 		} else {
 			log.ERROR.Printf("Error when sending a message: %v", err)
 		}

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"os"
 	"strings"
 	"sync"
@@ -22,6 +21,7 @@ import (
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 const (

--- a/v1/brokers/sqsv2/sqs.go
+++ b/v1/brokers/sqsv2/sqs.go
@@ -193,7 +193,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	result, err := b.service.SendMessage(ctx, MsgInput)
 
 	if err != nil {
-		log.INFO.Printf("Error when sending a message: %v", err)
+		log.DEBUG.Printf("Error when sending a message: %v", err)
 		return err
 
 	}


### PR DESCRIPTION
Problem: Non existent source queues are making noise in logs as they are being logged at ERROR level.

Solution: Make the source queues non existent error log at INFO level.

UT: 

<img width="3992" height="98" alt="image" src="https://github.com/user-attachments/assets/389b20e8-15ee-4c20-b02d-f2334d674706" />

