### PR TITLE
fix(worker): avoid logging broker when starting worker

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -53,7 +53,6 @@ func (worker *Worker) LaunchAsync(errorsChan chan<- error) {
 
 	// Log some useful information about worker configuration
 	log.INFO.Printf("Launching a worker with the following settings:")
-	log.INFO.Printf("- Broker: %s", cnf.Broker)
 	if worker.Queue == "" {
 		log.INFO.Printf("- DefaultQueue: %s", cnf.DefaultQueue)
 	} else {

--- a/v2/worker.go
+++ b/v2/worker.go
@@ -46,7 +46,6 @@ func (worker *Worker) LaunchAsync(errorsChan chan<- error) {
 
 	// Log some useful information about worker configuration
 	log.INFO.Printf("Launching a worker with the following settings:")
-	log.INFO.Printf("- Broker: %s", cnf.Broker)
 	if worker.Queue == "" {
 		log.INFO.Printf("- DefaultQueue: %s", cnf.DefaultQueue)
 	} else {


### PR DESCRIPTION
Logging the broker can expose credentials info in the case of certain brokers like redis, when the username and password is part of the connection string